### PR TITLE
fix(cicd): Fixed ambiguous line-endings for trickest wordlist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto
 *.txt text
+Discovery/Web-Content/trickest-robots-disallowed-wordlists/top-10000.txt text eol=lf
 *.zip -text
 *.tgz -text

--- a/.github/workflows/remote-wordlists-updater.yml
+++ b/.github/workflows/remote-wordlists-updater.yml
@@ -25,8 +25,8 @@ jobs:
               echo "[+] No files were changed"
           else
               echo "[+] Files were changed! Pushing changed..."
-              git add --renormalize -A && git add -A
               git add --renormalize Discovery/Web-Content/trickest-robots-disallowed-wordlists/top-10000.txt && git add Discovery/Web-Content/trickest-robots-disallowed-wordlists/top-10000.txt
+              git add --renormalize -A && git add -A
 
               git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
               git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
This is attempt n3 trying to fix the line-ending normalization issue present in the Discovery/Web-Content/trickest-robots-disallowed-wordlists/top-10000.txt wordlist.

This PR attempts to fix the issue by specifying `lf` for the `top-10000.txt` file in `.gitattributes`.